### PR TITLE
customize the max size so it will choose inline asset type

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,12 @@ module.exports = {
         rules: [
             {
                 test: /\.(png|jpg|jpeg)$/,
-                type: 'asset/resource'
+                type: 'asset',
+                parser: {
+                    dataUrlCondition: {
+                        maxSize:  3 * 1024 // 3 kilobytes
+                    } // condition based on which webpage decides if it should use asset inline or as a resource
+                } // accepts a JS object as a value
             }
         ]
     }


### PR DESCRIPTION
1. Choose general asset type. Webpack will choose how the image will build depending on its size. 
2. Customize max Size by setting up additional rule